### PR TITLE
Scaling in sliding overlays

### DIFF
--- a/butterfly_viewer/aux_functions.py
+++ b/butterfly_viewer/aux_functions.py
@@ -14,6 +14,74 @@ Credits:
 from PyQt5 import QtCore
 
 
+def determineSyncSenderDimension(width: int,
+                                 height: int,
+                                 sync_by: str="box"):
+    """Get the dimension of the sender image with which to synchronize zoom.
+    
+    Args:
+        width (int): Width of sender in pixels.
+        height (int): Height of sender in pixels.
+        sync_by (str): Method by which to sync zoom ("box", "width", "height", "pixel").
+
+    Returns:
+        dimension (int, None): Dimension with which to synchronize zoom (None if sync by pixel).
+    """
+
+    if sync_by == "width":
+        dimension = width
+    elif sync_by == "height":
+        dimension = height
+    elif sync_by == "pixel":
+        dimension = None
+    else:  # Equivalent to sync_by == "box"
+        # Tall image means the height dictates the size of the zoom box.
+        # Wide image means the width dictates the size of the zoom box.
+        if height >= width:
+            dimension = height
+        else:
+            dimension = width
+
+    return dimension
+
+
+
+def determineSyncAdjustmentFactor(sync_by: str,
+                                  sender_dimension: int,
+                                  receiver_width: int,
+                                  receiver_height: int):
+    """Get the factor with which to multiply the zoom of the sender before giving it to the receiver to synchronize them.
+
+    Returns 1 if receiver width or height are zero.
+    
+    Args:
+        sync_by (str): Method by which to sync zoom ("box", "width", "height", "pixel").
+        sender_dimension (int): Dimension of sender in pixels, as determined by determineSyncSenderDimension().
+        receiver_width (int): Width of receiver in pixels.
+        receiver_height (int): Height of sender in pixels.
+
+    Returns:
+        adjustment_factor (float): Factor with which to multiply the sender zoom to sync the receiver.
+    """
+
+    if (receiver_width == 0) or (receiver_height == 0):
+        return 1
+
+    if sync_by == "width":
+        adjustment_factor = sender_dimension/receiver_width
+    elif sync_by == "height":
+        adjustment_factor = sender_dimension/receiver_height
+    elif sync_by == "pixel":
+        adjustment_factor = 1.0
+    else: # "box"
+        if receiver_width >= receiver_height:
+            adjustment_factor = sender_dimension/receiver_width
+        else:
+            adjustment_factor = sender_dimension/receiver_height
+    
+    return adjustment_factor
+
+
 
 def strippedName(fullFilename):
     """Get filename from a filepath.


### PR DESCRIPTION
Achieves #42 by scaling non-main images in a sliding overlay so that they appear with the same size as the main image. Images are scaled using the fit-in-a-box method.