### PR TITLE
Replace <title> in feature request template with text 'Replace this text with a short title'

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request_issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_issue_form.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Request a feature with a form
-title: "[Feature] <title>"
+title: "[Feature] Replace this text with a short title"
 labels: ["feature"]
 body:
 - type: checkboxes


### PR DESCRIPTION
The <title> placeholder is not being recognized by users as something they should replace, so they instead keep it and write the title after it, resulting in titles like "[Feature] <title> Request for something".