### PR TITLE
Support command line arguments to immediately open into a comparison

### DIFF
--- a/butterfly_viewer/butterfly_viewer.py
+++ b/butterfly_viewer/butterfly_viewer.py
@@ -1999,8 +1999,8 @@ def main():
     # Note that despite using argparse, we still forward argv to QApplication further below, so that users can optionally
     # provide QT-specific arguments. Be sure to choose specific names for custom arguments that won't clash with QT.
     parser.add_argument('--hide', help='If provided, hides the interface on start.', action='store_true')
-    parser.add_argument('--fullscreen', help='If provided, fullscreens the interface on start.', action='store_true')
-    parser.add_argument('--paths', nargs="*", help='If provided, automatically creates individual image windows supplied by these paths.')
+    parser.add_argument('--fullscreen', help='If provided, fullscreens the app on start.', action='store_true')
+    parser.add_argument('--paths', nargs="*", help='If provided, automatically starts with individual (side by side) image windows supplied by these paths.')
     parser.add_argument('--overlay_path_main_topleft', help='If provided, automatically starts with the main image (top left) supplied by this path.')
     parser.add_argument('--overlay_path_topright', help='If provided, automatically starts with the top right image supplied by this path.')
     parser.add_argument('--overlay_path_bottomleft', help='If provided, automatically starts with the bottom left image supplied by this path.')

--- a/butterfly_viewer/butterfly_viewer.py
+++ b/butterfly_viewer/butterfly_viewer.py
@@ -1998,6 +1998,8 @@ def main():
 
     # Note that despite using argparse, we still forward argv to QApplication further below, so that users can optionally
     # provide QT-specific arguments. Be sure to choose specific names for custom arguments that won't clash with QT.
+    parser.add_argument('--hide', help='If provided, hides the interface on start.', action='store_true')
+    parser.add_argument('--fullscreen', help='If provided, fullscreens the interface on start.', action='store_true')
     parser.add_argument('--paths', nargs="*", help='If provided, automatically creates individual image windows supplied by these paths.')
     parser.add_argument('--overlay_path_main_topleft', help='If provided, automatically starts with the main image (top left) supplied by this path.')
     parser.add_argument('--overlay_path_topright', help='If provided, automatically starts with the top right image supplied by this path.')
@@ -2039,6 +2041,12 @@ def main():
 
     if preloadedImageCount >= 2:
         mainWin.on_create_splitview()
+
+    # Settings:
+    if args.hide:
+        mainWin.show_interface_off()
+    if args.fullscreen:
+        mainWin.set_fullscreen_on()
 
     mainWin.show()
     sys.exit(app.exec_())

--- a/butterfly_viewer/butterfly_viewer.py
+++ b/butterfly_viewer/butterfly_viewer.py
@@ -17,6 +17,7 @@ Credits:
 
 
 
+import argparse
 import sip
 import time
 import os
@@ -1990,8 +1991,20 @@ def main():
         app (QApplication): Starts and holds the main event loop of application.
         mainWin (MultiViewMainWindow): The main window.
     """
-    import sys
+    parser = argparse.ArgumentParser(
+                prog='Butterfly Viewer',
+                description='Side-by-side image viewer with synchronized zoom and sliding overlays. Further info: https://olive-groves.github.io/butterfly_viewer/'
+            )
 
+    # Note that despite using argparse, we still forward argv to QApplication further below, so that users can optionally
+    # provide QT-specific arguments. Be sure to choose specific names for custom arguments that won't clash with QT.
+    parser.add_argument('--image_path_main_topleft', help='If provided, automatically starts with the main image (top left) supplied by this path.')
+    parser.add_argument('--image_path_topright', help='If provided, automatically starts with the top right image supplied by this path.')
+    parser.add_argument('--image_path_bottomleft', help='If provided, automatically starts with the bottom left image supplied by this path.')
+    parser.add_argument('--image_path_bottomright', help='If provided, automatically starts with the bottom right image supplied by this path.')
+    args = parser.parse_args()
+
+    import sys
     app = QtWidgets.QApplication(sys.argv)
     QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
     app.setOrganizationName(COMPANY)
@@ -2003,8 +2016,26 @@ def main():
     mainWin = MultiViewMainWindow()
     mainWin.setWindowTitle(APPNAME)
 
-    mainWin.show()
+    # Load any predefined images:
+    dda = mainWin._splitview_creator.drag_drop_area
+    preloadedImageCount = 0
+    if args.image_path_main_topleft:
+        dda.app_main_topleft.load_image(args.image_path_main_topleft)
+        preloadedImageCount+=1
+    if args.image_path_bottomleft:
+        dda.app_bottomleft.load_image(args.image_path_bottomleft)
+        preloadedImageCount+=1
+    if args.image_path_topright:
+        dda.app_topright.load_image(args.image_path_topright)
+        preloadedImageCount+=1
+    if args.image_path_bottomright:
+        dda.app_bottomright.load_image(args.image_path_bottomright)
+        preloadedImageCount+=1
 
+    if preloadedImageCount >= 2:
+        mainWin.on_create_splitview()
+
+    mainWin.show()
     sys.exit(app.exec_())
 
 if __name__ == '__main__':

--- a/butterfly_viewer/butterfly_viewer.py
+++ b/butterfly_viewer/butterfly_viewer.py
@@ -1998,6 +1998,7 @@ def main():
 
     # Note that despite using argparse, we still forward argv to QApplication further below, so that users can optionally
     # provide QT-specific arguments. Be sure to choose specific names for custom arguments that won't clash with QT.
+    parser.add_argument('--paths', nargs="*", help='If provided, automatically creates individual image windows supplied by these paths.')
     parser.add_argument('--overlay_path_main_topleft', help='If provided, automatically starts with the main image (top left) supplied by this path.')
     parser.add_argument('--overlay_path_topright', help='If provided, automatically starts with the top right image supplied by this path.')
     parser.add_argument('--overlay_path_bottomleft', help='If provided, automatically starts with the bottom left image supplied by this path.')
@@ -2017,6 +2018,10 @@ def main():
     mainWin.setWindowTitle(APPNAME)
 
     # Load any predefined images:
+    if args.paths:
+        for path in args.paths:
+            mainWin.loadFile(path)
+
     dda = mainWin._splitview_creator.drag_drop_area
     preloadedImageCount = 0
     if args.overlay_path_main_topleft:

--- a/butterfly_viewer/butterfly_viewer.py
+++ b/butterfly_viewer/butterfly_viewer.py
@@ -1998,10 +1998,10 @@ def main():
 
     # Note that despite using argparse, we still forward argv to QApplication further below, so that users can optionally
     # provide QT-specific arguments. Be sure to choose specific names for custom arguments that won't clash with QT.
-    parser.add_argument('--image_path_main_topleft', help='If provided, automatically starts with the main image (top left) supplied by this path.')
-    parser.add_argument('--image_path_topright', help='If provided, automatically starts with the top right image supplied by this path.')
-    parser.add_argument('--image_path_bottomleft', help='If provided, automatically starts with the bottom left image supplied by this path.')
-    parser.add_argument('--image_path_bottomright', help='If provided, automatically starts with the bottom right image supplied by this path.')
+    parser.add_argument('--overlay_path_main_topleft', help='If provided, automatically starts with the main image (top left) supplied by this path.')
+    parser.add_argument('--overlay_path_topright', help='If provided, automatically starts with the top right image supplied by this path.')
+    parser.add_argument('--overlay_path_bottomleft', help='If provided, automatically starts with the bottom left image supplied by this path.')
+    parser.add_argument('--overlay_path_bottomright', help='If provided, automatically starts with the bottom right image supplied by this path.')
     args = parser.parse_args()
 
     import sys
@@ -2019,17 +2019,17 @@ def main():
     # Load any predefined images:
     dda = mainWin._splitview_creator.drag_drop_area
     preloadedImageCount = 0
-    if args.image_path_main_topleft:
-        dda.app_main_topleft.load_image(args.image_path_main_topleft)
+    if args.overlay_path_main_topleft:
+        dda.app_main_topleft.load_image(args.overlay_path_main_topleft)
         preloadedImageCount+=1
-    if args.image_path_bottomleft:
-        dda.app_bottomleft.load_image(args.image_path_bottomleft)
+    if args.overlay_path_bottomleft:
+        dda.app_bottomleft.load_image(args.overlay_path_bottomleft)
         preloadedImageCount+=1
-    if args.image_path_topright:
-        dda.app_topright.load_image(args.image_path_topright)
+    if args.overlay_path_topright:
+        dda.app_topright.load_image(args.overlay_path_topright)
         preloadedImageCount+=1
-    if args.image_path_bottomright:
-        dda.app_bottomright.load_image(args.image_path_bottomright)
+    if args.overlay_path_bottomright:
+        dda.app_bottomright.load_image(args.overlay_path_bottomright)
         preloadedImageCount+=1
 
     if preloadedImageCount >= 2:

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: C:\art\github\butterfly_viewer\env
+name: butterfly_viewer_env
 channels:
   - defaults
   - conda-forge


### PR DESCRIPTION
Fixes #44 

### Proposed changes

- Updated the conda environment name in `environment.yml` because the windows path as the conda name contain symbols that error on some systems.
- Added an argparse parser (not needed in conda environment since it ships with base python) with 4x arguments. 
  - These arguments reflect file paths.
  - The 4x widgets are correspondingly updated with the paths that are provided, if they are provided.
  - If 2 or more paths are provided, a split view is immediately started.
  
I kept these changes as surgical/minimal as possible to avoid any structural changes to the program. Thankfully it was simple to do.

Originally I attempted directly calling `loadFile()` but that does not update the other widgets and only creates the split view. Doing it this way by loading via the widgets and then calling the callback as though you pushed the button seems to preserve all the right behaviors.
  
  ### Testing
  
  I am on a Windows 11 system using MSYS2+bash as the terminal. 
  
  #### (1) Running the program without any arguments
  
  ```
  $ python ./butterfly_viewer/butterfly_viewer.py
  ```
  
  This opens the program as before, no images are loaded.
  
  #### (2) Using one preloaded image
  
  ```
  $ python ./butterfly_viewer/butterfly_viewer.py --image_path_main_topleft butterfly_viewer/icons/icon.png
  ``` 

This opens the viewer with an image in the overlay corner and nothing else:

![image](https://github.com/user-attachments/assets/d4ab2db3-dfab-49e6-b03e-3bd9882e9189)

#### (3) Using two preloaded images

I have a pink square png in a nearby folder I used for this one:

```
python ./butterfly_viewer/butterfly_viewer.py --image_path_main_topleft butterfly_viewer/icons/icon.png --image_path_topright ../../../missing_asset_square.png 
```

This opens the image viewer and it's already in sliding overlay mode. No time wasted! :)

![image](https://github.com/user-attachments/assets/6ed37299-5548-4f3e-8d62-6b71e3a69dae)


  
